### PR TITLE
speedup calls to map_coord_space

### DIFF
--- a/R/map_coord_space.R
+++ b/R/map_coord_space.R
@@ -8,37 +8,21 @@
 
 map_coord_space <- function(master, coord)
 {
-  #Convert master table into GRanges object to find overlaps in coord
-  master_gr <- GRanges(seqnames=c("chr1"), ranges=IRanges(start=master$start, end=master$end))
-  mcols(master_gr) <- master[,c('Type', 'trans_start', 'trans_end')]
-  
-  # Convert input coordinate to GRanges object then find the overlap between master and coord
-  coord_gr <- GRanges(seqnames=c("chr1"), ranges=IRanges(start=coord$start, end=coord$end))
-  overlap <- subsetByOverlaps(master_gr, coord_gr)
-    
-  # Convert the grange object specfying the overlap coord back to a data frame
-  master_range <- as.data.frame(ranges(overlap))
-  master_meta <- as.data.frame(mcols(overlap))
-  master_overlap <- cbind(master_range, master_meta)
-  master_overlap <- master_overlap[,c('start', 'end', 'width', 'Type', 'trans_start', 'trans_end')]
-  master_overlap$width <- master_overlap$trans_end - master_overlap$trans_start
-    
-  # Convert the grange object containing the coord to transform back to a data frame
-  coord_range <- as.data.frame(ranges(coord_gr))
-  coord_range <- coord_range[,c('start', 'end', 'width')]
-    
-  # Check that there is only 1 row in coord_range
-  if(nrow(coord_range) != 1)
-  {
-    stop("Expect data frame coord_range map_coord_space.R to be 1 row")
-  }
   
   # Map the original coordinates to the transformed space
-  n <- nrow(master_overlap)
-  fraction.overlap <- (master_overlap[1,]$end - coord_range$start + 1) / (master_overlap[1,]$end - master_overlap[1,]$start + 1)
-  trans_start <- master_overlap[1,]$trans_start + (1 - fraction.overlap) * master_overlap[1,]$width
-  fraction.overlap <- (coord_range$end - master_overlap[n,]$start + 1) / (master_overlap[n,]$end - master_overlap[n,]$start + 1)
-  trans_end <- master_overlap[n,]$trans_start + fraction.overlap * master_overlap[n,]$width
+  lt <- coord$start <= master$end
+  gt <- coord$end >= master$start
+  
+  idx = which(lt & gt)
+  n <- length(idx)
+  
+  start.row <- master[idx[1],]
+  end.row <- master[idx[n],]
+  
+  overlap <- (start.row$end - coord$start + 1) / (start.row$end - start.row$start + 1)
+  trans_start <- start.row$trans_start + (1 - overlap) * start.row$width
+  overlap <- (coord$end - end.row$start + 1) / (end.row$end - end.row$start + 1)
+  trans_end <- end.row$trans_start + overlap * end.row$width
   
   # Add in the new transformed coordinates to the coord object
   coord$trans_start <- trans_start

--- a/R/plot_coverage.R
+++ b/R/plot_coverage.R
@@ -93,7 +93,5 @@ plot_coverage <- function(coverage_data, txdb, gr, genome, reduce=F, gene_colour
   track_coverage_plot <- plot_track(merged_data, gene_name=gene_name, bg_fill=bg_fill, text_fill=text_fill,
                                     border=border, size=size, axis_align='width', width_ratio=width_ratio, nested_list=T)
   
-  stopCluster(cl)
-  
   return(track_coverage_plot)
 }

--- a/Test_data/Cov_plot_test.R
+++ b/Test_data/Cov_plot_test.R
@@ -1,5 +1,5 @@
-setwd("/Users/zskidmor/GGgenome/Test_data")
-#setwd("/Users/awagner/Workspace/R/GGgenome/Test_data")
+#setwd("/Users/zskidmor/GGgenome/Test_data")
+setwd("/Users/awagner/Workspace/R/GGgenome/Test_data")
 # need a biostrings object for reference
 require(BSgenome.Hsapiens.UCSC.hg19)
 genome <- BSgenome.Hsapiens.UCSC.hg19
@@ -9,8 +9,8 @@ require(TxDb.Hsapiens.UCSC.hg19.knownGene)
 txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
 
 # need Granges object 
-gr <- GRanges(seqnames=c("chr16"), ranges=IRanges(start=c(67063051), end=c(67134782)), strand=strand(c("+")))
-#gr <- GRanges(seqnames=c("chr16"), ranges=IRanges(start=c(67063091), end=c(67063151)), strand=strand(c("+")))
+#gr <- GRanges(seqnames=c("chr16"), ranges=IRanges(start=c(67063051), end=c(67134782)), strand=strand(c("+")))
+gr <- GRanges(seqnames=c("chr16"), ranges=IRanges(start=c(67063051), end=c(67065051)), strand=strand(c("+")))
 
 # need coverage data and extra stuff to make plot work
 cov <- read.delim('CBFB_TCGA_Cov.bed')
@@ -20,6 +20,6 @@ cov <- as.data.frame(cbind(cov[,3], cov[,'cov']))
 colnames(cov) <- c('end', 'cov')
 data <- list("RNA" = cov)
 
-test <- gene_plot(txdb, gr, genome, reduce=T, transform=c('Intron','UTR','CDS'))
-#test <- plot_coverage(data, txdb, gr, genome, reduce=F, transform=c('Intron','UTR','CDS'), cores=8)
+# test <- gene_plot(txdb, gr, genome, reduce=T, transform=c('Intron','UTR','CDS'))
+test <- plot_coverage(data, txdb, gr, genome, reduce=F, transform=c('Intron','UTR','CDS'))
 # test <- plot_track('CBFB'=gene, 'Cov'=test_plot, 'Cov'=test_plot, border='green', axis_align='width', width_ratio=c(1,10))


### PR DESCRIPTION
This is the first of two speedup branches. This one greatly improves calls to `map_coord_space`. The second will focus on speedups in the `format(cds|threeUTR|fiveUTR)` family. This first fix will bring the runtime down under a minute for 70kb of coverage data.
