### PR TITLE
Fixes #33.

### DIFF
--- a/R/genCov.R
+++ b/R/genCov.R
@@ -50,7 +50,7 @@ genCov <- function(x, txdb, gr, genome, reduce=F, gene_colour=NULL, gene_name='G
   display_x_axis <- TRUE
   
   # perform the intronic transform on the coverage data
-  if(length(transform) > 0)
+  if(transform != NULL && length(transform) > 0)
   {
     # Obtain a copy of the master gene file
     master <- gp_result$master

--- a/R/gene_plot.R
+++ b/R/gene_plot.R
@@ -52,7 +52,7 @@ gene_plot <- function(txdb, gr, genome, reduce=FALSE, gene_colour=NULL, base=c(1
   xlimits <- c(start(gr), end(gr))
   
   # Create a master table based on log transform(s) then use the master table as a map for mapping coordinates to transformed space
-  if(length(transform) > 0)
+  if(transform != NULL && length(transform) > 0)
   {
     # status message
     message("Calculating transform")
@@ -62,6 +62,8 @@ gene_plot <- function(txdb, gr, genome, reduce=FALSE, gene_colour=NULL, base=c(1
     
     # Map the original coordinates into transformed space
     gene_features <- lapply(gene_features, function(x, master) adply(x, 1, map_coord_space, master=master), master=master)
+  } else {
+    master <- NULL
   }
   
   # Adjust the Y axis gene locations based on the presense of isoforms


### PR DESCRIPTION
`NULL` now usable as `transform` attribute setting in `genCov`.