### PR TITLE
fixes #30

### DIFF
--- a/R/build_gene.R
+++ b/R/build_gene.R
@@ -7,10 +7,12 @@
 #' @param display_axis Boolean specifying whether to display X axis coordinate values
 #' @param x_limits vector specifying x-axis limits of plot
 #' @param gene_colour character specifying colour of gene to be plotted
+#' @param transcript_name Boolean specifying whether to plot USCS transcript names
+#' @param transcript_name_size Integer specifying the size of the transcript name text
 #' @return ggplot object
 #' @import ggplot2
 
-build_gene <- function(data_frame, display_x_axis=T, x_limits=NULL, gene_colour=NULL)
+build_gene <- function(data_frame, display_x_axis=T, x_limits=NULL, gene_colour=NULL, transcript_name=FALSE, transcript_name_size=6)
 { 
   # Define various parameters of plot
   if(is.null(gene_colour))
@@ -18,6 +20,16 @@ build_gene <- function(data_frame, display_x_axis=T, x_limits=NULL, gene_colour=
     gene_features <- geom_rect(data=data_frame, mapping=aes(xmin=start, xmax=end, ymin=Upper, ymax=Lower, fill=GC))
   } else {
     gene_features <- geom_rect(data=data_frame, mapping=aes(xmin=start, xmax=end, ymin=Upper, ymax=Lower), fill=gene_colour)
+  }
+  
+  if(transcript_name == TRUE)
+  {
+    transcript_data_x <- aggregate(start ~ txname, data=data_frame, min)
+    transcript_data_y <- aggregate(Mid ~ txname, data=data_frame, max)
+    transcript_data <- merge(transcript_data_x, transcript_data_y, by="txname")
+    transcript_name <- geom_text(data=transcript_data, mapping=aes(x=start-1, y=Mid, label=txname), angle=90, vjust=0, size=transcript_name_size)
+  } else {
+    transcript_name <- geom_blank()
   }
   
   gene_track <- geom_segment(data=data_frame, mapping=aes(x=segStart, xend=segEnd, y=Mid, yend=Mid))
@@ -37,7 +49,8 @@ build_gene <- function(data_frame, display_x_axis=T, x_limits=NULL, gene_colour=
   }
   
   # Define the main plot
-  gene_plot <- ggplot() + gene_track + gene_features + theme + xlimits
+  
+  gene_plot <- ggplot() + gene_track + gene_features + theme + xlimits + transcript_name
   
   return(gene_plot)
 }

--- a/R/genCov.R
+++ b/R/genCov.R
@@ -19,6 +19,8 @@
 #' @param cores Integer specifying the number of cores to use for processing
 #' @param base A vector of log bases to transform the data, corresponding to the elements of transform 
 #' @param transform A vector of strings designating what objects to log transform
+#' @param plot_transcript_name Boolean specifying whether to plot the transcript name
+#' @param transcript_name_size Integer specifying the size of the transcript name text
 #' @return ggplot object
 #' @export
 #' @import GenomicRanges
@@ -26,11 +28,13 @@
 
 genCov <- function(x, txdb, gr, genome, reduce=F, gene_colour=NULL, gene_name='Gene', bg_fill="black", 
                           text_fill="white", border="black", size=10, width_ratio=c(1, 10), colour="blue",
-                          plot_type="line", base=c(10,2,2), transform=c('Intron','CDS','UTR')){
+                          plot_type="line", base=c(10,2,2), transform=c('Intron','CDS','UTR'),
+                          plot_transcript_name=TRUE, transcript_name_size=6){
   
   # Obtain a plot for the gene overlapping the Granges object and covert to a named list
   gp_result <- gene_plot(txdb, gr, genome, reduce=reduce, gene_colour=gene_colour,
-                    base=base, transform=transform)
+                    base=base, transform=transform, transcript_name_size=transcript_name_size,
+                    plot_transcript_name=plot_transcript_name)
   gene <- gp_result$plot
   gene_list <- list()
   gene_list[[gene_name]] <- gene

--- a/R/gene_plot.R
+++ b/R/gene_plot.R
@@ -8,13 +8,15 @@
 #' @param reduce Boolean specifying whether to collapse isoforms in the ROI
 #' @param base  base A vector of log bases to transform the data, corresponding to the elements of transform 
 #' @param transform A vector of strings designating what objects to log transform
+#' @param plot_transcript_name Boolean specifying whether to plot the transcript name
+#' @param transcript_name_size Integer specifying the size of the transcript name text
 #' @return ggplot object
 #' @export
 #' @import GenomicRanges
 #' @import plyr
 #' @import GenomicFeatures
 
-gene_plot <- function(txdb, gr, genome, reduce=FALSE, gene_colour=NULL, base=c(10,2,2), transform=c('Intron','CDS','UTR')){
+gene_plot <- function(txdb, gr, genome, reduce=FALSE, gene_colour=NULL, base=c(10,2,2), transform=c('Intron','CDS','UTR'), plot_transcript_name=TRUE, transcript_name_size=6){
 
   # extract a data frame for each type of gene feature given a transcript database and Granges object as a list
   cds <- formatCDS(txdb, gr, genome=genome, reduce=reduce)
@@ -105,7 +107,14 @@ gene_plot <- function(txdb, gr, genome, reduce=FALSE, gene_colour=NULL, base=c(1
   }
   
   # construct the gene in gplot
-  gene_plot <- build_gene(gene_features, display_x_axis=display_x_axis, x_limits=xlimits, gene_colour=gene_colour)
+  if(reduce == TRUE || plot_transcript_name == FALSE)
+  {
+    gene_plot <- build_gene(gene_features, display_x_axis=display_x_axis, x_limits=xlimits, gene_colour=gene_colour, transcript_name=FALSE)
+  } else if(reduce == FALSE && plot_transcript_name == TRUE)
+  {
+    gene_plot <- build_gene(gene_features, display_x_axis=display_x_axis, x_limits=xlimits, gene_colour=gene_colour, transcript_name=TRUE, transcript_name_size=transcript_name_size)
+  }
+  
   out <- list('plot' = gene_plot, 'features' = gene_features, 'master' = master)
   return(out)
 }

--- a/man/build_gene.Rd
+++ b/man/build_gene.Rd
@@ -5,7 +5,7 @@
 \title{build gene plot}
 \usage{
 build_gene(data_frame, display_x_axis = T, x_limits = NULL,
-  gene_colour = NULL)
+  gene_colour = NULL, transcript_name = FALSE, transcript_name_size = 6)
 }
 \arguments{
 \item{data_frame}{an object of class data frame specifying gene feature information}
@@ -13,6 +13,10 @@ build_gene(data_frame, display_x_axis = T, x_limits = NULL,
 \item{x_limits}{vector specifying x-axis limits of plot}
 
 \item{gene_colour}{character specifying colour of gene to be plotted}
+
+\item{transcript_name}{Boolean specifying whether to plot USCS transcript names}
+
+\item{transcript_name_size}{Integer specifying the size of the transcript name text}
 
 \item{master_gene}{an object of class data frame specifying the master gene feature information resultant of compression}
 

--- a/man/genCov.Rd
+++ b/man/genCov.Rd
@@ -8,7 +8,7 @@ genCov(x, txdb, gr, genome, reduce = F, gene_colour = NULL,
   gene_name = "Gene", bg_fill = "black", text_fill = "white",
   border = "black", size = 10, width_ratio = c(1, 10), colour = "blue",
   plot_type = "line", base = c(10, 2, 2), transform = c("Intron", "CDS",
-  "UTR"))
+  "UTR"), plot_transcript_name = TRUE, transcript_name_size = 6)
 }
 \arguments{
 \item{x}{named list containing data frames with columns stop and cov}
@@ -42,6 +42,10 @@ genCov(x, txdb, gr, genome, reduce = F, gene_colour = NULL,
 \item{base}{A vector of log bases to transform the data, corresponding to the elements of transform}
 
 \item{transform}{A vector of strings designating what objects to log transform}
+
+\item{plot_transcript_name}{Boolean specifying whether to plot the transcript name}
+
+\item{transcript_name_size}{Integer specifying the size of the transcript name text}
 
 \item{cores}{Integer specifying the number of cores to use for processing}
 }

--- a/man/gene_plot.Rd
+++ b/man/gene_plot.Rd
@@ -5,7 +5,8 @@
 \title{plot gene}
 \usage{
 gene_plot(txdb, gr, genome, reduce = FALSE, gene_colour = NULL,
-  base = c(10, 2, 2), transform = c("Intron", "CDS", "UTR"))
+  base = c(10, 2, 2), transform = c("Intron", "CDS", "UTR"),
+  plot_transcript_name = TRUE, transcript_name_size = 6)
 }
 \arguments{
 \item{txdb}{A TxDb object for a genome}
@@ -19,6 +20,10 @@ gene_plot(txdb, gr, genome, reduce = FALSE, gene_colour = NULL,
 \item{base}{base A vector of log bases to transform the data, corresponding to the elements of transform}
 
 \item{transform}{A vector of strings designating what objects to log transform}
+
+\item{plot_transcript_name}{Boolean specifying whether to plot the transcript name}
+
+\item{transcript_name_size}{Integer specifying the size of the transcript name text}
 }
 \value{
 ggplot object


### PR DESCRIPTION
UCSC transcript names are now optionally used to label transcripts, because the transcription metadatabases already in bioconductor are from UCSC. The user should be able to create an ensembl txdb object if they would want transcripts based off of ensembl instead.