### PR TITLE
Fixed https://github.com/griffithlab/GenVisR/issues/386#issue-1286049415

### DIFF
--- a/R/geneViz_formatUTR.R
+++ b/R/geneViz_formatUTR.R
@@ -20,6 +20,10 @@ geneViz_formatUTR <- function(txdb=NULL, gr=NULL, genome=NULL, reduce=FALSE)
     if(is.null(UTR)){
         return(NA)
     }
+    if(is.na(UTR)){
+        return(NA)
+    }
+
   # Calculate GC content for retrieved data
     UTR <- sapply(UTR, geneViz_calcGC, genome=genome)
 


### PR DESCRIPTION
Catches NAs in geneViz_formatUTR(), which currently causes an error if a gene does not have annotated UTRs.